### PR TITLE
cb - create database table for HelpRequest

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
@@ -23,6 +23,7 @@ public class HelpRequest {
 
   private String requesterEmail;
   private String teamId;
+  private String tableOrBreakoutRoom;
   private LocalDateTime requestTime;
   private String explanation;
   private boolean solved;

--- a/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
@@ -1,0 +1,29 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** This is a JPA entity that represents a HelpRequest */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "helprequests")
+public class HelpRequest {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String requesterEmail;
+  private String teamId;
+  private LocalDateTime requestTime;
+  private String explanation;
+  private boolean solved;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/HelpRequestRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/HelpRequestRepository.java
@@ -8,14 +8,4 @@ import org.springframework.stereotype.Repository;
 /** The HelpRequestRepository is a repository for HepRequest entities. */
 @Repository
 @RepositoryRestResource(exported = false)
-public interface HelpRequestRepository extends CrudRepository<HelpRequest, Long> {
-  // /**
-  //  * This method returns all UCSBDate entities with a given quarterYYYYQ.
-  //  *
-  //  * @param quarterYYYYQ quarter in the format YYYYQ (e.g. 20241 for Winter 2024, 20242 for
-  // Spring
-  //  *     2024, 20243 for Summer 2024, 20244 for Fall 2024)
-  //  * @return all UCSBDate entities with a given quarterYYYYQ
-  //  */
-  // Iterable<UCSBDate> findAllByQuarterYYYYQ(String quarterYYYYQ);
-}
+public interface HelpRequestRepository extends CrudRepository<HelpRequest, Long> {}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/HelpRequestRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/HelpRequestRepository.java
@@ -1,0 +1,21 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.HelpRequest;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.stereotype.Repository;
+
+/** The HelpRequestRepository is a repository for HepRequest entities. */
+@Repository
+@RepositoryRestResource(exported = false)
+public interface HelpRequestRepository extends CrudRepository<HelpRequest, Long> {
+  // /**
+  //  * This method returns all UCSBDate entities with a given quarterYYYYQ.
+  //  *
+  //  * @param quarterYYYYQ quarter in the format YYYYQ (e.g. 20241 for Winter 2024, 20242 for
+  // Spring
+  //  *     2024, 20243 for Summer 2024, 20244 for Fall 2024)
+  //  * @return all UCSBDate entities with a given quarterYYYYQ
+  //  */
+  // Iterable<UCSBDate> findAllByQuarterYYYYQ(String quarterYYYYQ);
+}

--- a/src/main/resources/db/migration/changes/HelpRequest.json
+++ b/src/main/resources/db/migration/changes/HelpRequest.json
@@ -1,0 +1,80 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "HelpRequest-1",
+          "author": "chaehana",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "HELPREQUESTS"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "HELPREQUEST_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column":{
+                      "name": "REQUESTER_EMAIL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "TEAM_ID",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "TABLE_OR_BREAKOUT_ROOM",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "REQUEST_TIME",
+                      "type": "TIMESTAMP"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "EXPLANATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "SOLVED",
+                      "type": "BOOLEAN"
+                    }
+                  }
+                ],
+                "tableName": "HELPREQUESTS"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
Closes #32 

In this pr, I have created database table that represents Help requests with the following fields:

```
String requesterEmail;
String teamId;
String tableOrBreakoutRoom;
LocalDateTime requestTime;
String explanation;
boolean solved;
```

You can test this code by running on localhost and check for HelpRequests table using H2 console, which will look like this:

<img width="203" height="171" alt="image" src="https://github.com/user-attachments/assets/c8b6b9eb-00c1-42d4-b54b-2f796b17f66b" />

You can also test this by running on dokku, connecting to postgres database, and using comand "\dt", you will see:

```cbang@dokku-06:~$ dokku postgres:connect team01-dev-chaehana-db
psql (15.2 (Debian 15.2-1.pgdg110+1))
SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, compression: off)
Type "help" for help.

team01_dev_chaehana_db=# \dt
                 List of relations
 Schema |         Name          | Type  |  Owner   
--------+-----------------------+-------+----------
 public | databasechangelog     | table | postgres
 public | databasechangeloglock | table | postgres
 public | helprequests          | table | postgres
 public | jobs                  | table | postgres
 public | restaurants           | table | postgres
 public | ucsbdates             | table | postgres
 public | ucsbdiningcommons     | table | postgres
 public | urls                  | table | postgres
 public | users                 | table | postgres
(9 rows)

```