### PR TITLE
dx- create RecommendationRequest database table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/entities/RecommendationRequest.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/RecommendationRequest.java
@@ -1,0 +1,30 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** This is a JPA entity that represents a Recommendation Request. */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "recommendationrequests")
+public class RecommendationRequest {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String requesterEmail;
+  private String professorEmail;
+  private String explanation;
+  private LocalDateTime dateRequested;
+  private LocalDateTime dateNeeded;
+  private boolean done;
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/RecommendationRequest.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/RecommendationRequest.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-@Entity(name = "recommendationrequests")
+@Entity(name = "RECOMMENDATIONREQUESTS")
 public class RecommendationRequest {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/edu/ucsb/cs156/example/repositories/RecommendationRequestRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/RecommendationRequestRepository.java
@@ -1,0 +1,12 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.RecommendationRequest;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.stereotype.Repository;
+
+/** The RecommendationRequestRepository is a repository for RecommendationRequest entities. */
+@Repository
+@RepositoryRestResource(exported = false)
+public interface RecommendationRequestRepository
+    extends CrudRepository<RecommendationRequest, Long> {}

--- a/src/main/resources/db/migration/changes/RecommendationRequest.json
+++ b/src/main/resources/db/migration/changes/RecommendationRequest.json
@@ -54,13 +54,13 @@
                   {
                     "column": {
                       "name": "DATE_REQUESTED",
-                      "type": "TIMESTAMP WITH TIME ZONE"
+                      "type": "TIMESTAMP"
                     }
                   },
                   {
                     "column": {
                       "name": "DATE_NEEDED",
-                      "type": "TIMESTAMP WITH TIME ZONE"
+                      "type": "TIMESTAMP"
                     }
                   },
                   {

--- a/src/main/resources/db/migration/changes/RecommendationRequest.json
+++ b/src/main/resources/db/migration/changes/RecommendationRequest.json
@@ -1,0 +1,80 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "RecommendationRequests-1",
+          "author": "dongyi-xia",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "RECOMMENDATIONREQUESTS"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "RECOMMENDATIONREQUESTS_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "REQUESTER_EMAIL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "PROFESSOR_EMAIL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "EXPLANATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DATE_REQUESTED",
+                      "type": "TIMESTAMP WITH TIME ZONE"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DATE_NEEDED",
+                      "type": "TIMESTAMP WITH TIME ZONE"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DONE",
+                      "type": "BOOLEAN"
+                    }
+                  }
+                ],
+                "tableName": "RECOMMENDATIONREQUESTS"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
Closes #20 

In this PR, we add a database that represents a recommendation request, with the following fields: 
```
String requesterEmail
String professorEmail
String explanation
LocalDateTime dateRequested
LocalDateTime dateNeeded
boolean done
```

You can test this by running on localhost and looking for the RecommendationRequest table on the h2-console.

<img width="206" height="172" alt="Screenshot 2026-04-28 at 5 06 08 PM" src="https://github.com/user-attachments/assets/580d71db-b1d7-4c93-9a45-90e685da38be" />

You can also test this by running on dokku and connecting to the postgres database, and running \dt:

```
dongyi_xia@dokku-06:~$ dokku postgres:connect team01-dev-dongyi-xia-db
psql (15.2 (Debian 15.2-1.pgdg110+1))
SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, compression: off)
Type "help" for help.

team01_dev_dongyi_xia_db=# \dt
                 List of relations
 Schema |          Name          | Type  |  Owner   
--------+------------------------+-------+----------
 public | databasechangelog      | table | postgres
 public | databasechangeloglock  | table | postgres
 public | jobs                   | table | postgres
 public | recommendationrequests | table | postgres
 public | restaurants            | table | postgres
 public | ucsbdates              | table | postgres
 public | ucsbdiningcommons      | table | postgres
 public | urls                   | table | postgres
 public | users                  | table | postgres
(9 rows)

team01_dev_dongyi_xia_db=#
```