### PR TITLE
ah - create menu item review controller

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -55,22 +55,21 @@ public class MenuItemReviewController extends ApiController {
       @Parameter(name = "itemId") @RequestParam long itemId,
       @Parameter(name = "reviewerEmail") @RequestParam String reviewerEmail,
       @Parameter(name = "stars") @RequestParam int stars,
-      @Parameter(name = "dateReviewed") @RequestParam LocalDateTime dateReviewed,
       @Parameter(name = "comments") @RequestParam String comments,
       // do i need this?
       @Parameter(
-              name = "menuItemReviewTime",
+              name = "dateReviewed",
               description =
                   "date (in iso format, e.g. YYYY-mm-ddTHH:MM:SSZ; see https://en.wikipedia.org/wiki/ISO_8601)")
-          @RequestParam("menuItemReviewTime")
+          @RequestParam("dateReviewed")
           @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-          LocalDateTime menuItemReviewTime)
+          LocalDateTime dateReviewed)
       throws JsonProcessingException {
 
     // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     // See: https://www.baeldung.com/spring-date-parameters
 
-    log.info("menuItemReviewTime={}", menuItemReviewTime);
+    log.info("dateReviewed={}", dateReviewed);
 
     MenuItemReview menuItemReview = new MenuItemReview();
     menuItemReview.setComments(comments);

--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -1,0 +1,86 @@
+package edu.ucsb.cs156.example.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+import edu.ucsb.cs156.example.repositories.MenuItemReviewRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** This is a REST controller for MenuItemreviews */
+@Tag(name = "MenuItemReview")
+@RequestMapping("/api/menuitemreview")
+@RestController
+@Slf4j
+public class MenuItemReviewController extends ApiController {
+  @Autowired MenuItemReviewRepository menuItemReviewRepository;
+
+  /**
+   * List all MenuItemReviews
+   *
+   * @return an iterable of MenuItemReviews
+   */
+  @Operation(summary = "List all menu item reviews")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/all")
+  public Iterable<MenuItemReview> allMenuItemReviews() {
+    Iterable<MenuItemReview> menuItemReviews = menuItemReviewRepository.findAll();
+    return menuItemReviews;
+  }
+
+  /**
+   * Create a new menuItemReview
+   *
+   * @param itemId the id of the thing
+   * @param reviewerEmail the email of the reviewer
+   * @param stars the number of stars
+   * @param dateReviewed the date of the review
+   * @param comments the comments in the review
+   * @return the saved menuItemReview
+   */
+  @Operation(summary = "Create a new date")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PostMapping("/post")
+  public MenuItemReview postMenuItemreview(
+      @Parameter(name = "itemId") @RequestParam long itemId,
+      @Parameter(name = "reviewerEmail") @RequestParam String reviewerEmail,
+      @Parameter(name = "stars") @RequestParam int stars,
+      @Parameter(name = "dateReviewed") @RequestParam LocalDateTime dateReviewed,
+      @Parameter(name = "comments") @RequestParam String comments,
+      // do i need this?
+      @Parameter(
+              name = "menuItemReviewTime",
+              description =
+                  "date (in iso format, e.g. YYYY-mm-ddTHH:MM:SSZ; see https://en.wikipedia.org/wiki/ISO_8601)")
+          @RequestParam("menuItemReviewTime")
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          LocalDateTime menuItemReviewTime)
+      throws JsonProcessingException {
+
+    // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    // See: https://www.baeldung.com/spring-date-parameters
+
+    log.info("menuItemReviewTime={}", menuItemReviewTime);
+
+    MenuItemReview menuItemReview = new MenuItemReview();
+    menuItemReview.setComments(comments);
+    menuItemReview.setDateReviewed(dateReviewed);
+    menuItemReview.setItemId(itemId);
+    menuItemReview.setReviewerEmail(reviewerEmail);
+    menuItemReview.setStars(stars);
+
+    MenuItemReview savedMenuItemReview = menuItemReviewRepository.save(menuItemReview);
+
+    return savedMenuItemReview;
+  }
+}

--- a/src/main/resources/db/migration/changes/MenuItemReview.json
+++ b/src/main/resources/db/migration/changes/MenuItemReview.json
@@ -53,7 +53,7 @@
                   },
                   {
                   "column": {
-                    "name": "LOCAL_DATE_TIME",
+                    "name": "DATE_REVIEWED",
                      "type": "TIMESTAMP"
                   }
                 },

--- a/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
@@ -1,0 +1,146 @@
+package edu.ucsb.cs156.example.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+import edu.ucsb.cs156.example.repositories.MenuItemReviewRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(controllers = MenuItemReviewController.class)
+@Import(TestConfig.class)
+public class MenuItemReviewControllerTests extends ControllerTestCase {
+  @MockitoBean MenuItemReviewRepository menuItemReviewRepository;
+
+  @MockitoBean UserRepository userRepository;
+
+  @Test
+  public void logged_out_users_cannot_get_all() throws Exception {
+    mockMvc
+        .perform(get("/api/menuitemreview/all"))
+        .andExpect(status().is(403)); // logged out users can't get all
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_users_can_get_all() throws Exception {
+    mockMvc.perform(get("/api/menuitemreview/all")).andExpect(status().is(200)); // logged
+  }
+
+  @Test
+  public void logged_out_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/menuitemreview/post")
+                .param("itemId", "1")
+                .param("reviewerEmail", "cgaucho@ucsb.edu")
+                .param("stars", "5")
+                .param("comments", "Fantastic food!")
+                .param("dateReviewed", "2022-01-03T00:00:00")
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/menuitemreview/post")
+                .param("itemId", "1")
+                .param("reviewerEmail", "cgaucho@ucsb.edu")
+                .param("stars", "5")
+                .param("comments", "Fantastic food!")
+                .param("dateReviewed", "2022-01-03T00:00:00")
+                .with(csrf()))
+        .andExpect(status().is(403)); // only admins can post
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_user_can_get_all_ucsbdates() throws Exception {
+
+    // arrange
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+    MenuItemReview menuItemReview1 =
+        MenuItemReview.builder()
+            .itemId(1)
+            .reviewerEmail("cgaucho@ucsb.edu")
+            .stars(5)
+            .comments("Fantastic food!")
+            .dateReviewed(ldt1)
+            .build();
+
+    // LocalDateTime ldt2 = LocalDateTime.parse("2022-03-11T00:00:00");
+    ArrayList<MenuItemReview> expectedMIRs = new ArrayList<>();
+    expectedMIRs.add(menuItemReview1);
+    when(menuItemReviewRepository.findAll()).thenReturn(expectedMIRs);
+
+    // act
+    MvcResult response =
+        mockMvc.perform(get("/api/menuitemreview/all")).andExpect(status().isOk()).andReturn();
+
+    // assert
+
+    verify(menuItemReviewRepository, times(1)).findAll();
+    String expectedJson = mapper.writeValueAsString(expectedMIRs);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void an_admin_user_can_post_a_new_ucsbdate() throws Exception {
+    // arrange
+
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+    MenuItemReview menuItemReview1 =
+        MenuItemReview.builder()
+            .itemId(1)
+            .reviewerEmail("cgaucho@ucsb.edu")
+            .stars(5)
+            .comments("Fantastic food!")
+            .dateReviewed(ldt1)
+            .build();
+
+    when(menuItemReviewRepository.save(eq(menuItemReview1))).thenReturn(menuItemReview1);
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/menuitemreview/post")
+                    .param("itemId", "1")
+                    .param("reviewerEmail", "cgaucho@ucsb.edu")
+                    .param("stars", "5")
+                    .param("comments", "Fantastic food!")
+                    .param("dateReviewed", "2022-01-03T00:00:00")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(menuItemReviewRepository, times(1)).save(menuItemReview1);
+    String expectedJson = mapper.writeValueAsString(menuItemReview1);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+}


### PR DESCRIPTION
Closes #27 

We added /api/commits/all and /api/commits/post endpoint for reading all commits , and creting a single commit. We add a GET /all for menu item reviews and a POST to create a menu item review.


This is for menu item review post:
<img width="1270" height="661" alt="Screenshot 2026-04-28 at 6 43 48 PM" src="https://github.com/user-attachments/assets/4fa1ea37-c227-4b35-9be4-f6cef761e603" />

This is for menu review item all:
<img width="1161" height="630" alt="Screenshot 2026-04-28 at 6 43 12 PM" src="https://github.com/user-attachments/assets/72043ebf-dc6d-4c30-a5d5-1af752589240" />
