### PR TITLE
ev-MenuItem-add-put-endpoint

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -110,4 +110,34 @@ public class UCSBDiningCommonsMenuItemController extends ApiController {
             .orElseThrow(() -> new EntityNotFoundException("id %s not found".formatted(id)));
     return menuItem;
   }
+
+  /**
+   * Update a single menu item
+   *
+   * @param id database id of the menu item to update
+   * @param incoming the new menu item values
+   * @return the updated menu item
+   */
+  @Operation(
+      summary =
+          "Update a single menu item, ex: PUT /api/ucsbdiningcommonsmenuitem?id=xxx, takes JSON of new values")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PutMapping("")
+  public UCSBDiningCommonsMenuItem updateUCSBDiningCommonsMenuItem(
+      @Parameter(name = "id") @RequestParam Long id,
+      @RequestBody UCSBDiningCommonsMenuItem incoming) {
+
+    UCSBDiningCommonsMenuItem menuItem =
+        ucsbDiningCommonsMenuItemRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
+
+    menuItem.setDiningCommonsCode(incoming.getDiningCommonsCode());
+    menuItem.setName(incoming.getName());
+    menuItem.setStation(incoming.getStation());
+
+    ucsbDiningCommonsMenuItemRepository.save(menuItem);
+
+    return menuItem;
+  }
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -76,9 +76,10 @@ public class UCSBDiningCommonsMenuItemController extends ApiController {
    * Delete a single menu item by id, ex: /api/ucsbdiningcommonsmenuitem?id=XXX
    *
    * @param id the id of the menu item
-   * @return the id that was deleted (if it exists) or was not deleted (if not found)
+   * @return if exists "record XXX deleted" if DNE "record XXX not found"
    */
-  @Operation(summary = "Delete a single menu item")
+  @Operation(
+      summary = "Delete a single menu item by id, ex: DELETE /api/ucsbdiningcommonsmenuitem?id=XXX")
   @PreAuthorize("hasRole('ROLE_ADMIN')")
   @DeleteMapping("")
   public Object deleteById(@Parameter(name = "id") @RequestParam Long id) {

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -2,6 +2,7 @@ package edu.ucsb.cs156.example.controllers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
 import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -69,5 +70,23 @@ public class UCSBDiningCommonsMenuItemController extends ApiController {
     UCSBDiningCommonsMenuItem savedMenuItem = ucsbDiningCommonsMenuItemRepository.save(menuItem);
 
     return savedMenuItem;
+  }
+
+  /**
+   * Delete a single menu item by id
+   *
+   * @param id the id of the menu item
+   * @return the id that was deleted (if it exists) or was not deleted (if not found)
+   */
+  @Operation(summary = "Delete a single menu item")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @DeleteMapping("")
+  public Object deleteById(@Parameter(name = "id") @RequestParam Long id) {
+    UCSBDiningCommonsMenuItem menuItem =
+        ucsbDiningCommonsMenuItemRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
+    ucsbDiningCommonsMenuItemRepository.delete(menuItem);
+    return genericMessage("UCSBDiningCommonsMenuItem with id %s deleted".formatted(id));
   }
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -12,7 +12,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 /** This is a REST controller for UCSBDiningCommonsMenuItem */
-@Tag(name = "UCSBDiningCommonsMenuItemController")
+@Tag(name = "UCSBDiningCommonsMenuItem")
 @RequestMapping("/api/ucsbdiningcommonsmenuitem")
 @RestController
 @Slf4j
@@ -20,11 +20,11 @@ public class UCSBDiningCommonsMenuItemController extends ApiController {
   @Autowired UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
 
   /**
-   * List all UCSB Dining common Menu Items
+   * List all UCSB Dining Commons menu items
    *
-   * @return an iterable of UCSBDate
+   * @return an iterable of UCSBDiningCommonsMenuItem
    */
-  @Operation(summary = "List all ucsb dining commons menu items")
+  @Operation(summary = "List all UCSB Dining Commons menu items")
   @PreAuthorize("hasRole('ROLE_USER')")
   @GetMapping("/all")
   public Iterable<UCSBDiningCommonsMenuItem> allUCSBDiningCommonsMenuItems() {
@@ -35,19 +35,31 @@ public class UCSBDiningCommonsMenuItemController extends ApiController {
   /**
    * Create a new menu item
    *
-   * @param diningCommonsCode the code of the dining commons
+   * @param diningCommonsCode the code of the dining commons (e.g. "ortega", "dlg")
    * @param name the name of the menu item
-   * @param station the station of the menu item (e.g. "Entrees" "Desserts")
+   * @param station the station where the item is served (e.g. "Entrees", "Desserts")
    * @return the saved menu item
    */
   @Operation(summary = "Create a new menu item")
   @PreAuthorize("hasRole('ROLE_ADMIN')")
   @PostMapping("/post")
   public UCSBDiningCommonsMenuItem postUCSBDiningCommonsMenuItem(
-      @Parameter(name = "diningCommonsCode") @RequestParam String diningCommonsCode,
-      @Parameter(name = "name") @RequestParam String name,
-      @Parameter(name = "station") @RequestParam String station)
+      @Parameter(
+              name = "diningCommonsCode",
+              description = "Code of the dining commons (e.g. ortega, dlg)")
+          @RequestParam
+          String diningCommonsCode,
+      @Parameter(name = "name", description = "Name of the menu item (e.g. 'chicken')")
+          @RequestParam
+          String name,
+      @Parameter(
+              name = "station",
+              description = "Station where the item is served (e.g. Entrees, Desserts)")
+          @RequestParam
+          String station)
       throws JsonProcessingException {
+    // if any of the parameters are empty or null, ??
+
     UCSBDiningCommonsMenuItem menuItem =
         UCSBDiningCommonsMenuItem.builder()
             .diningCommonsCode(diningCommonsCode)

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -86,7 +86,7 @@ public class UCSBDiningCommonsMenuItemController extends ApiController {
     UCSBDiningCommonsMenuItem menuItem =
         ucsbDiningCommonsMenuItemRepository
             .findById(id)
-            .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
+            .orElseThrow(() -> new EntityNotFoundException("record %s not found".formatted(id)));
     ucsbDiningCommonsMenuItemRepository.delete(menuItem);
     return genericMessage("record %s deleted".formatted(id));
   }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -1,0 +1,61 @@
+package edu.ucsb.cs156.example.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+/** This is a REST controller for UCSBDiningCommonsMenuItem */
+@Tag(name = "UCSBDiningCommonsMenuItemController")
+@RequestMapping("/api/ucsbdiningcommonsmenuitem")
+@RestController
+@Slf4j
+public class UCSBDiningCommonsMenuItemController extends ApiController {
+  @Autowired UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
+
+  /**
+   * List all UCSB Dining common Menu Items
+   *
+   * @return an iterable of UCSBDate
+   */
+  @Operation(summary = "List all ucsb dining commons menu items")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/all")
+  public Iterable<UCSBDiningCommonsMenuItem> allUCSBDiningCommonsMenuItems() {
+    Iterable<UCSBDiningCommonsMenuItem> menuItems = ucsbDiningCommonsMenuItemRepository.findAll();
+    return menuItems;
+  }
+
+  /**
+   * Create a new menu item
+   *
+   * @param diningCommonsCode the code of the dining commons
+   * @param name the name of the menu item
+   * @param station the station of the menu item (e.g. "Entrees" "Desserts")
+   * @return the saved menu item
+   */
+  @Operation(summary = "Create a new menu item")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PostMapping("/post")
+  public UCSBDiningCommonsMenuItem postUCSBDiningCommonsMenuItem(
+      @Parameter(name = "diningCommonsCode") @RequestParam String diningCommonsCode,
+      @Parameter(name = "name") @RequestParam String name,
+      @Parameter(name = "station") @RequestParam String station)
+      throws JsonProcessingException {
+    UCSBDiningCommonsMenuItem menuItem =
+        UCSBDiningCommonsMenuItem.builder()
+            .diningCommonsCode(diningCommonsCode)
+            .name(name)
+            .station(station)
+            .build();
+    UCSBDiningCommonsMenuItem savedMenuItem = ucsbDiningCommonsMenuItemRepository.save(menuItem);
+
+    return savedMenuItem;
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -73,7 +73,7 @@ public class UCSBDiningCommonsMenuItemController extends ApiController {
   }
 
   /**
-   * Delete a single menu item by id
+   * Delete a single menu item by id, ex: /api/ucsbdiningcommonsmenuitem?id=XXX
    *
    * @param id the id of the menu item
    * @return the id that was deleted (if it exists) or was not deleted (if not found)
@@ -87,6 +87,6 @@ public class UCSBDiningCommonsMenuItemController extends ApiController {
             .findById(id)
             .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
     ucsbDiningCommonsMenuItemRepository.delete(menuItem);
-    return genericMessage("UCSBDiningCommonsMenuItem with id %s deleted".formatted(id));
+    return genericMessage("record %s deleted".formatted(id));
   }
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -90,4 +90,24 @@ public class UCSBDiningCommonsMenuItemController extends ApiController {
     ucsbDiningCommonsMenuItemRepository.delete(menuItem);
     return genericMessage("record %s deleted".formatted(id));
   }
+
+  /**
+   * Get a single record from the table by databse id
+   *
+   * @param id of the menu item record
+   * @return JSON of the database record with id XXX if exists, error message "id XXX not found" if
+   *     DNE
+   */
+  @Operation(
+      summary =
+          "Get a single record from the table by databse id, ex: GET /api/ucsbdiningcommonsmenuitem?id=XXX")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("")
+  public UCSBDiningCommonsMenuItem getById(@Parameter(name = "id") @RequestParam Long id) {
+    UCSBDiningCommonsMenuItem menuItem =
+        ucsbDiningCommonsMenuItemRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException("id %s not found".formatted(id)));
+    return menuItem;
+  }
 }

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
@@ -1,0 +1,29 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * This is a JPA entity that represents the menu items a UCSB Dining Commons has available, i.e. an
+ * entry that comes from the UCSB API for menu items
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "ucsbdiningcommonsmenuitem")
+public class UCSBDiningCommonsMenuItem {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String diningCommonsCode;
+  private String name;
+  private String station;
+}

--- a/src/main/java/edu/ucsb/cs156/example/errors/EntityNotFoundException.java
+++ b/src/main/java/edu/ucsb/cs156/example/errors/EntityNotFoundException.java
@@ -14,4 +14,8 @@ public class EntityNotFoundException extends RuntimeException {
   public EntityNotFoundException(Class<?> entityType, Object id) {
     super("%s with id %s not found".formatted(entityType.getSimpleName(), id.toString()));
   }
+
+  public EntityNotFoundException(String s) {
+    super(s);
+  }
 }

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
@@ -1,0 +1,15 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.stereotype.Repository;
+
+/**
+ * The UCSBDiningCommonsMenuItemRepository is a repository for UCSB Dining Commons Menu Items
+ * entities.
+ */
+@Repository
+@RepositoryRestResource(exported = false)
+public interface UCSBDiningCommonsMenuItemRepository
+    extends CrudRepository<UCSBDiningCommonsMenuItem, Long> {}

--- a/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItem.json
+++ b/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItem.json
@@ -1,0 +1,62 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "UCSBDiningCommonsMenuItem-1",
+          "author": "Mr465truck",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "UCSBDININGCOMMONSMENUITEM"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "UCSBDININGCOMMONSMENUITEM_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DINING_COMMONS_CODE",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "NAME",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "STATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  }
+                ],
+                "tableName": "UCSBDININGCOMMONSMENUITEM"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
@@ -142,7 +142,7 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
         .andExpect(status().is(403)); // only admins can post
   }
 
-  // Authorization tests for delete with id
+  // Authorization tests for DELETE /api/ucsbdiningcommonsmenuitem?id=XXX
   @WithMockUser(roles = {"USER"})
   @Test
   public void logged_in_regular_users_cannot_delete() throws Exception {
@@ -164,7 +164,7 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
     // ensure that response message is correct
     String responseBody = result.getResponse().getContentAsString();
     Map<String, Object> json = mapper.readValue(responseBody, Map.class);
-    assertEquals("UCSBDiningCommonsMenuItem with id 123 not found", json.get("message"));
+    assertEquals("record 123 not found", json.get("message"));
 
     UCSBDiningCommonsMenuItem menuItem =
         UCSBDiningCommonsMenuItem.builder()

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
@@ -71,7 +71,7 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
     assertEquals(expectedJson, responseString);
   }
 
-  // Authorization tests for /api/ucsbdiningcommonsmenuitem?id=XXX (getById)
+  // Authorization tests for GET /api/ucsbdiningcommonsmenuitem?id=XXX (getById)
 
   @Test
   public void logged_out_users_cannot_get_by_id() throws Exception {

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
@@ -71,6 +71,50 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
     assertEquals(expectedJson, responseString);
   }
 
+  // Authorization tests for /api/ucsbdiningcommonsmenuitem?id=XXX (getById)
+
+  @Test
+  public void logged_out_users_cannot_get_by_id() throws Exception {
+    mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem?id=123")).andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_users_can_get_by_id_with_empty_database() throws Exception {
+    // test with no data, expect 404
+    MvcResult result =
+        mockMvc
+            .perform(get("/api/ucsbdiningcommonsmenuitem?id=123"))
+            .andExpect(status().is(404))
+            .andReturn();
+    String responseBody = result.getResponse().getContentAsString();
+    Map<String, Object> json = mapper.readValue(responseBody, Map.class);
+    assertEquals("id 123 not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_users_can_get_by_id_with_real_data() throws Exception {
+    // test with sample values
+    UCSBDiningCommonsMenuItem menuItem =
+        UCSBDiningCommonsMenuItem.builder()
+            .diningCommonsCode("ortega")
+            .name("chicken")
+            .station("entree")
+            .build();
+    when(ucsbDiningCommonsMenuItemRepository.findById(0L)).thenReturn(Optional.of(menuItem));
+
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/ucsbdiningcommonsmenuitem?id=0"))
+            .andExpect(status().isOk())
+            .andReturn();
+    verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(0L);
+    String expectedJson = mapper.writeValueAsString(menuItem);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
   // Authorization tests for /api/ucsbdiningcommonsmenuitem/post
 
   @Test

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
@@ -1,0 +1,131 @@
+package edu.ucsb.cs156.example.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(controllers = UCSBDiningCommonsMenuItemController.class)
+@Import(TestConfig.class)
+public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase {
+
+  @MockitoBean UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
+  @MockitoBean UserRepository userRepository;
+
+  // Authorization tests for /api/ucsbdiningcommonsmenuitem/admin/all
+
+  @Test
+  public void logged_out_users_cannot_get_all() throws Exception {
+    mockMvc
+        .perform(get("/api/ucsbdiningcommonsmenuitem/all"))
+        .andExpect(status().is(403)); // logged out users can't get all
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_users_can_get_all() throws Exception {
+    // check with empty database
+    mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem/all")).andExpect(status().is(200));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_users_can_get_all_with_real_data() throws Exception {
+    // check with sample values
+    UCSBDiningCommonsMenuItem menuItem =
+        UCSBDiningCommonsMenuItem.builder()
+            .diningCommonsCode("ortega")
+            .name("chicken")
+            .station("entree")
+            .build();
+    ArrayList<UCSBDiningCommonsMenuItem> menuItems = new ArrayList<>(Arrays.asList(menuItem));
+    when(ucsbDiningCommonsMenuItemRepository.findAll()).thenReturn(menuItems);
+
+    // ensure that the return is correct
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/ucsbdiningcommonsmenuitem/all"))
+            .andExpect(status().isOk())
+            .andReturn();
+    verify(ucsbDiningCommonsMenuItemRepository, times(1)).findAll();
+    String expectedJson = mapper.writeValueAsString(menuItems);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  // Authorization tests for /api/ucsbdiningcommonsmenuitem/post
+
+  @Test
+  public void logged_out_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/ucsbdiningcommonsmenuitem/post")
+                .param("diningCommonsCode", "ortega")
+                .param("name", "chicken")
+                .param("station", "entree")
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/ucsbdiningcommonsmenuitem/post")
+                .param("diningCommonsCode", "ortega")
+                .param("name", "chicken")
+                .param("station", "entree")
+                .with(csrf()))
+        .andExpect(status().is(403)); // only admins can post
+  }
+
+  // Test that admins can create a new menu item
+  @WithMockUser(roles = {"ADMIN"})
+  @Test
+  public void logged_in_admin_can_create_menu_item() throws Exception {
+
+    UCSBDiningCommonsMenuItem expectedItem =
+        UCSBDiningCommonsMenuItem.builder()
+            .diningCommonsCode("ortega")
+            .name("chicken")
+            .station("entree")
+            .build();
+
+    when(ucsbDiningCommonsMenuItemRepository.save(any())).thenReturn(expectedItem);
+
+    // check for 200 status
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/ucsbdiningcommonsmenuitem/post")
+                    .param("diningCommonsCode", "ortega")
+                    .param("name", "chicken")
+                    .param("station", "entree")
+                    .with(csrf()))
+            .andExpect(status().is(200))
+            .andReturn();
+
+    String expectedJson = mapper.writeValueAsString(expectedItem);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
@@ -14,8 +14,7 @@ import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
 import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
 import edu.ucsb.cs156.example.repositories.UserRepository;
 import edu.ucsb.cs156.example.testconfig.TestConfig;
-import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.*;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -56,7 +55,8 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
             .name("chicken")
             .station("entree")
             .build();
-    ArrayList<UCSBDiningCommonsMenuItem> menuItems = new ArrayList<>(Arrays.asList(menuItem));
+    ArrayList<UCSBDiningCommonsMenuItem> menuItems =
+        new ArrayList<>(Collections.singletonList(menuItem));
     when(ucsbDiningCommonsMenuItemRepository.findAll()).thenReturn(menuItems);
 
     // ensure that the return is correct
@@ -96,6 +96,49 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
                 .param("station", "entree")
                 .with(csrf()))
         .andExpect(status().is(403)); // only admins can post
+  }
+
+  // Authorization tests for delete with id
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_delete() throws Exception {
+    mockMvc
+        .perform(delete("/api/ucsbdiningcommonsmenuitem?id=123").param("id", "123").with(csrf()))
+        // regular users cannot delete
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"ADMIN"})
+  @Test
+  public void logged_in_admin_can_delete() throws Exception {
+    // test with no data, expect 404
+    MvcResult result =
+        mockMvc
+            .perform(delete("/api/ucsbdiningcommonsmenuitem?id=123").with(csrf()))
+            .andExpect(status().is(404))
+            .andReturn();
+    // ensure that response message is correct
+    String responseBody = result.getResponse().getContentAsString();
+    Map<String, Object> json = mapper.readValue(responseBody, Map.class);
+    assertEquals("UCSBDiningCommonsMenuItem with id 123 not found", json.get("message"));
+
+    UCSBDiningCommonsMenuItem menuItem =
+        UCSBDiningCommonsMenuItem.builder()
+            .diningCommonsCode("ortega")
+            .name("chicken")
+            .station("entree")
+            .build();
+    when(ucsbDiningCommonsMenuItemRepository.findById(0L)).thenReturn(Optional.of(menuItem));
+    result =
+        mockMvc
+            .perform(delete("/api/ucsbdiningcommonsmenuitem?id=0").with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+    // ensure that response message is correct
+    responseBody = result.getResponse().getContentAsString();
+    json = mapper.readValue(responseBody, Map.class);
+    assertEquals("record 0 deleted", json.get("message"));
+    verify(ucsbDiningCommonsMenuItemRepository, times(1)).delete(menuItem);
   }
 
   // Test that admins can create a new menu item

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
@@ -115,6 +115,79 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
     assertEquals(expectedJson, responseString);
   }
 
+  // Tests for PUT /api/ucsbdiningcommonsmenuitem?id=XXX
+
+  @WithMockUser(roles = {"ADMIN"})
+  @Test
+  public void admin_can_edit_an_existing_menu_item() throws Exception {
+    UCSBDiningCommonsMenuItem menuItemOrig =
+        UCSBDiningCommonsMenuItem.builder()
+            .diningCommonsCode("ortega")
+            .name("chicken")
+            .station("entree")
+            .build();
+
+    UCSBDiningCommonsMenuItem menuItemEdited =
+        UCSBDiningCommonsMenuItem.builder()
+            .diningCommonsCode("dlg")
+            .name("pizza")
+            .station("pizza station")
+            .build();
+
+    String requestBody = mapper.writeValueAsString(menuItemEdited);
+
+    when(ucsbDiningCommonsMenuItemRepository.findById(67L)).thenReturn(Optional.of(menuItemOrig));
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/ucsbdiningcommonsmenuitem")
+                    .param("id", "67")
+                    .header("Content-Type", "application/json")
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(67L);
+    verify(ucsbDiningCommonsMenuItemRepository, times(1)).save(menuItemEdited);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(requestBody, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN"})
+  @Test
+  public void admin_cannot_edit_menu_item_that_does_not_exist() throws Exception {
+    UCSBDiningCommonsMenuItem menuItemEdited =
+        UCSBDiningCommonsMenuItem.builder()
+            .diningCommonsCode("ortega")
+            .name("chicken")
+            .station("entree")
+            .build();
+
+    String requestBody = mapper.writeValueAsString(menuItemEdited);
+
+    when(ucsbDiningCommonsMenuItemRepository.findById(67L)).thenReturn(Optional.empty());
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/ucsbdiningcommonsmenuitem")
+                    .param("id", "67")
+                    .header("Content-Type", "application/json")
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(67L);
+    String responseBody = response.getResponse().getContentAsString();
+    Map<String, Object> json = mapper.readValue(responseBody, Map.class);
+    assertEquals("UCSBDiningCommonsMenuItem with id 67 not found", json.get("message"));
+  }
+
   // Authorization tests for /api/ucsbdiningcommonsmenuitem/post
 
   @Test


### PR DESCRIPTION
Closes #11
added put endpoint for menuitem to update a single item by its database value
to check: deploy locally & on dokku, ensure that it returns 403 when not logged in, 403 when logged in as user, when admin: returns 404 with message not found if DNE, returns json of the database record with new id and updated values when it does exist. check the database with the get all after running to ensure values are actually updated. dokku deployment: https://team01-dev-mr465truck.dokku-06.cs.ucsb.edu/